### PR TITLE
Update builder to Ubuntu 22.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     name: Dbeaver CE AppImage
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v2
+      - name: Install libfuse2
+        run: sudo apt-get install -y libfuse2
       - name: Build
         id: build
         uses: valicm/appimage-bash@main


### PR DESCRIPTION
Additionally, libfuse2 will be installed as this is required for appimages on Ubuntu 22.04+